### PR TITLE
Rename the mislabeled Select button to Delete Selected

### DIFF
--- a/index.cgi
+++ b/index.cgi
@@ -86,7 +86,7 @@ print ui_tabs_start_tab('mode', 'existing');
     print &ui_form_start("delete_server.cgi", "get");
     print &ui_links_row(\@links);
     print &ui_columns_start([
-    $text{'index_delete'},
+    "",
     $text{'index_name'},
 	$text{'index_enabled'},
     $text{'index_addr'}.$text{'sep_by'}." '".$config{'join_ch'}."'",

--- a/lang/en
+++ b/lang/en
@@ -7,7 +7,6 @@ index_modify=<br /><br /> 1) Module configuration is probably incorrect - click 
 index_install=, or <br /><br /> 2)
 index_mismatch=<p>Nginx is installed at <tt>$1</tt>, but the path in your configuration settings is <tt>$2</tt>.</p>
 
-index_delete=Delete
 index_enabled=Active (click to toggle)?
 index_name=Server Name
 index_addr=Address
@@ -18,6 +17,8 @@ index_view=View
 
 disa=Active : (click to Disable <i class="fa fa-unlink"></i>)
 enab=(click to Enable <i class="fa fa-link"></i>)
+
+index_delete=Delete Servers
 
 gl_edit=Edit nginx.conf
 gl_proxy=Edit proxy.conf

--- a/lang/en
+++ b/lang/en
@@ -7,7 +7,7 @@ index_modify=<br /><br /> 1) Module configuration is probably incorrect - click 
 index_install=, or <br /><br /> 2)
 index_mismatch=<p>Nginx is installed at <tt>$1</tt>, but the path in your configuration settings is <tt>$2</tt>.</p>
 
-index_delete=Select
+index_delete=Delete
 index_enabled=Active (click to toggle)?
 index_name=Server Name
 index_addr=Address


### PR DESCRIPTION
This does two things: drops the heading from the checkbox column (which is currently Select), and renames the button below the virtual host list back from Select to Delete Selected.

This is inspired by how the Perl module listing (Others -> Perl modules) acts.
